### PR TITLE
Sort Query Params

### DIFF
--- a/addon/components/imgix-photo.js
+++ b/addon/components/imgix-photo.js
@@ -5,6 +5,8 @@ import { and } from '@ember/object/computed';
 
 import { task, waitForEvent } from 'ember-concurrency';
 
+import buildQueryParams from '../utils/build-query-params';
+
 /**
  * Display an image we have previously uploaded the Imgix API.
  *
@@ -58,14 +60,7 @@ export default Component.extend({
     let params = this.params || {};
     let finalParams = Object.assign(defaultParams, params);
 
-    let joinedParams = Object
-      .entries(finalParams)
-      .map(function([key, value]) {
-        return `${key}=${value}`;
-      })
-      .join('&');
-
-    return joinedParams;
+    return buildQueryParams(finalParams);
   }),
 
   imgSrc: computed('url', 'queryParams', function() {

--- a/addon/utils/build-query-params.js
+++ b/addon/utils/build-query-params.js
@@ -1,0 +1,14 @@
+/**
+ * Builds a sorted query param string
+ */
+export default function buildQueryParams(params) {
+  return Object
+    .entries(params)
+    .sort(function([k1], [k2]) {
+      return k1.localeCompare(k2);
+    })
+    .map(function([key, value]) {
+      return `${key}=${value}`;
+    })
+    .join('&');
+}

--- a/app/utils/build-query-params.js
+++ b/app/utils/build-query-params.js
@@ -1,0 +1,1 @@
+export { default } from '@precision-nutrition/imgix-photo/utils/build-query-params';

--- a/testem.js
+++ b/testem.js
@@ -14,7 +14,6 @@ module.exports = {
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
         '--disable-gpu',
-        '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',
         '--remote-debugging-port=0',

--- a/tests/integration/components/imgix-photo-test.js
+++ b/tests/integration/components/imgix-photo-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | imgix-photo', function(hooks) {
 
     let dpr = window.devicePixelRatio;
 
-    let expectedSrc = `${actualImgUrl}?dpr=${dpr}&w=300&h=400&fit=crop&sepia=88`;
+    let expectedSrc = `${actualImgUrl}?dpr=${dpr}&fit=crop&h=400&sepia=88&w=300`;
 
     await render(hbs`{{imgix-photo
       url=url
@@ -58,7 +58,7 @@ module('Integration | Component | imgix-photo', function(hooks) {
 
     let dpr = window.devicePixelRatio;
 
-    let expectedSrc = `${actualImgUrl}?dpr=${dpr}&w=300&h=400&fit=crop&sepia=88`;
+    let expectedSrc = `${actualImgUrl}?dpr=${dpr}&fit=crop&h=400&sepia=88&w=300`;
 
     await render(hbs`{{imgix-photo
       autoSetDimensions=false


### PR DESCRIPTION
This prevents handwritten Imgix URLs from causing a cache hit. Use the
`buildQueryParams` util to build the query param if you need it.