### PR TITLE
[SP-837] Handle HEIC Images

### DIFF
--- a/tests/integration/components/imgix-photo-test.js
+++ b/tests/integration/components/imgix-photo-test.js
@@ -79,4 +79,71 @@ module('Integration | Component | imgix-photo', function(hooks) {
 
     assert.dom('img').hasAttribute('src', expectedSrc);
   });
+
+  test('converts HEIC images auto-magically', async function(assert) {
+    let heicUrl = 'http://example.com/image.heic';
+
+    this.setProperties({
+      alt: 'Test!',
+      url: heicUrl,
+      w: 300,
+      h: 400,
+      fit: 'crop',
+      sepia: 88,
+    });
+
+
+    let dpr = window.devicePixelRatio;
+
+    let expectedSrc = `${heicUrl}?dpr=${dpr}&fit=crop&fm=jpg&h=400&sepia=88&w=300`;
+
+    await render(hbs`<ImgixPhoto
+      @autoSetDimensions={{false}}
+      @url={{url}}
+      @alt={{alt}}
+      @params={{hash
+        w=w
+        h=h
+        fit=fit
+        sepia=sepia
+      }}
+      class="SomeClass"
+    />`);
+
+    assert.dom('img').hasAttribute('src', expectedSrc);
+  });
+
+  test('does not stomp on `fm` if provided for a HEIC image', async function(assert) {
+    let heicUrl = 'http://example.com/image.heic';
+
+    this.setProperties({
+      alt: 'Test!',
+      url: heicUrl,
+      w: 300,
+      h: 400,
+      fit: 'crop',
+      fm: 'png',
+      sepia: 88,
+    });
+
+    let dpr = window.devicePixelRatio;
+
+    let expectedSrc = `${heicUrl}?dpr=${dpr}&fit=crop&fm=png&h=400&sepia=88&w=300`;
+
+    await render(hbs`<ImgixPhoto
+      @autoSetDimensions={{false}}
+      @url={{url}}
+      @alt={{alt}}
+      @params={{hash
+        w=w
+        h=h
+        fit=fit
+        fm=fm
+        sepia=sepia
+      }}
+      class="SomeClass"
+    />`);
+
+    assert.dom('img').hasAttribute('src', expectedSrc);
+  });
 });

--- a/tests/integration/components/imgix-photo-test.js
+++ b/tests/integration/components/imgix-photo-test.js
@@ -146,4 +146,21 @@ module('Integration | Component | imgix-photo', function(hooks) {
 
     assert.dom('img').hasAttribute('src', expectedSrc);
   });
+
+  test('when no params provided', async function(assert) {
+    this.setProperties({
+      url: actualImgUrl,
+    });
+
+    let dpr = window.devicePixelRatio;
+
+    let expectedSrc = `${actualImgUrl}?dpr=${dpr}`;
+
+    await render(hbs`<ImgixPhoto
+      @url={{url}}
+      class="SomeClass"
+    />`);
+
+    assert.dom('img').hasAttribute('src', expectedSrc);
+  });
 });

--- a/tests/integration/components/imgix-photo-test.js
+++ b/tests/integration/components/imgix-photo-test.js
@@ -15,24 +15,24 @@ module('Integration | Component | imgix-photo', function(hooks) {
       w: 300,
       h: 400,
       fit: 'crop',
-      sepia: 88
+      sepia: 88,
     });
 
     let dpr = window.devicePixelRatio;
 
     let expectedSrc = `${actualImgUrl}?dpr=${dpr}&fit=crop&h=400&sepia=88&w=300`;
 
-    await render(hbs`{{imgix-photo
-      url=url
-      alt=alt
-      params=(hash
+    await render(hbs`<ImgixPhoto
+      @url={{url}}
+      @alt={{alt}}
+      @params={{hash
         w=w
         h=h
         fit=fit
         sepia=sepia
-      )
+      }}
       class="SomeClass"
-    }}`);
+    />`);
 
     assert.dom('img').hasAttribute('width', '300');
 
@@ -52,7 +52,7 @@ module('Integration | Component | imgix-photo', function(hooks) {
       w: 300,
       h: 400,
       fit: 'crop',
-      sepia: 88
+      sepia: 88,
     });
 
 
@@ -60,18 +60,18 @@ module('Integration | Component | imgix-photo', function(hooks) {
 
     let expectedSrc = `${actualImgUrl}?dpr=${dpr}&fit=crop&h=400&sepia=88&w=300`;
 
-    await render(hbs`{{imgix-photo
-      autoSetDimensions=false
-      url=url
-      alt=alt
-      params=(hash
+    await render(hbs`<ImgixPhoto
+      @autoSetDimensions={{false}}
+      @url={{url}}
+      @alt={{alt}}
+      @params={{hash
         w=w
         h=h
         fit=fit
         sepia=sepia
-      )
+      }}
       class="SomeClass"
-    }}`);
+    />`);
 
     assert.dom('img').doesNotHaveAttribute('width', '300');
 


### PR DESCRIPTION
No browser vendors support rendering these images, so we need to convert
them into something meaningful. I'm arbitrarily picking JPEG format.

See [`fm` on Imgix](https://docs.imgix.com/apis/url/format/fm) for further details.

Suggested version released: 1.3.0