### PR TITLE
[SP-2176] PoC: leave url alone when it has query params

### DIFF
--- a/addon/components/imgix-photo.js
+++ b/addon/components/imgix-photo.js
@@ -78,6 +78,14 @@ export default class ImgixPhoto extends Component {
   }
 
   get imgSrc() {
+    if (this.args.url.match(/\?/)) {
+      if (this.args.params) {
+        console.warn('ImgixPhoto was given a `url` which contains query params. Ignoring `params` attribute.');
+      }
+
+      return this.args.url;
+    }
+
     return `${this.args.url}?${this.queryParams}`;
   }
 }


### PR DESCRIPTION
This would be the first change we'd have to make in order to start allowing the path for backend driven imgix URLs:

See:
- https://github.com/PrecisionNutrition/eternal-sledgehammer/pull/5571
- https://github.com/PrecisionNutrition/fitpro/pull/1472
- https://github.com/PrecisionNutrition/academy/pull/154